### PR TITLE
Adds ca65 to comments file to get ctrl-/ line comment support.

### DIFF
--- a/Preferences/Comments.tmPreferences
+++ b/Preferences/Comments.tmPreferences
@@ -5,7 +5,7 @@
 	<key>name</key>
 	<string>Comments</string>
 	<key>scope</key>
-	<string>source.asm.65816</string>
+	<string>source.asm.65816,source.asm.ca65</string>
 	<key>settings</key>
 	<dict>
 		<key>shellVariables</key>


### PR DESCRIPTION
Pretty straight-forward, enabling ctrl-/ support for ca65 source code in Sublime Text.